### PR TITLE
All entities should now use the visible fields method

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/DetailsViewDefaultFields.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/DetailsViewDefaultFields.java
@@ -15,6 +15,11 @@ package com.hpe.adm.octane.ideplugins.intellij.ui.detail;
 
 public class DetailsViewDefaultFields {
 
+    //System fields
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_SUBTYPE = "subtype";
+    public static final String FIELD_TYPE = "type";
+
     public static final String FIELD_DEFECT_TYPE = "defect_type";
     public static final String FIELD_DESCRIPTION = "description";
     public static final String FIELD_FEATURE = "parent";

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/GeneralEntityDetailsPanel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/GeneralEntityDetailsPanel.java
@@ -427,7 +427,7 @@ public class GeneralEntityDetailsPanel extends JPanel implements Scrollable {
         GridBagLayout mainPaneGrid = new GridBagLayout();
         mainPaneGrid.columnWidths = new int[]{0, 0};
         mainPaneGrid.rowHeights = new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-        mainPaneGrid.columnWeights = new double[]{0.5, 1.0};
+        mainPaneGrid.columnWeights = new double[]{0.5, 0.5};
         mainPaneGrid.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
         detailsPanelMain.setLayout(mainPaneGrid);
         return detailsPanelMain;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/GeneralEntityDetailsPanel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/GeneralEntityDetailsPanel.java
@@ -43,6 +43,7 @@ import java.awt.event.ComponentEvent;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class GeneralEntityDetailsPanel extends JPanel implements Scrollable {
 
@@ -291,7 +292,10 @@ public class GeneralEntityDetailsPanel extends JPanel implements Scrollable {
     public void setFieldSelectButton(EntityDetailPresenter.SelectFieldsAction fieldSelectButton) {
         headerPanel.setFieldSelectButton(fieldSelectButton);
         fieldsPopup = new FieldsSelectFrame(defaultFields.get(Entity.getEntityType(entityModel)),
-                fields,
+                fields.stream().filter(e -> !"subtype".equals(e.getName())
+                                            &&!"description".equals(e.getName())
+                                            &&!"phase".equals(e.getName())
+                                            &&!"name".equals(e.getName())).collect(Collectors.toList()),
                 selectedFields,
                 Entity.getEntityType(entityModel),
                 idePluginPersistentState,

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/GeneralEntityDetailsPanel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/GeneralEntityDetailsPanel.java
@@ -40,10 +40,13 @@ import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.intellij.icons.AllIcons.Json.Array;
 
 public class GeneralEntityDetailsPanel extends JPanel implements Scrollable {
 
@@ -292,10 +295,7 @@ public class GeneralEntityDetailsPanel extends JPanel implements Scrollable {
     public void setFieldSelectButton(EntityDetailPresenter.SelectFieldsAction fieldSelectButton) {
         headerPanel.setFieldSelectButton(fieldSelectButton);
         fieldsPopup = new FieldsSelectFrame(defaultFields.get(Entity.getEntityType(entityModel)),
-                fields.stream().filter(e -> !"subtype".equals(e.getName())
-                                            &&!"description".equals(e.getName())
-                                            &&!"phase".equals(e.getName())
-                                            &&!"name".equals(e.getName())).collect(Collectors.toList()),
+                fields.stream().filter(e -> !Arrays.asList("phase", "name", "subtype", "description").contains(e.getName())).collect(Collectors.toList()),
                 selectedFields,
                 Entity.getEntityType(entityModel),
                 idePluginPersistentState,


### PR DESCRIPTION
Hi, the old solution does not fix the dropdown for the exceptions. So they have more fields there than they should. @kdrtibor is that correct? I'm not 100% sure.

Anyway the problem is the subtype field, if we make sure it's set, i.e. do it manually. The visible fields method will work on everything.

WDYT?