### PR TITLE
changes the limit of the retrieved entities count

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
@@ -99,7 +99,7 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
 
             public void run(@NotNull ProgressIndicator indicator) {
                 entityTreeView.setLoading(true);
-                searchResults = entitySearchService.searchGlobal(query, 20, searchEntityTypes);
+                searchResults = entitySearchService.searchGlobal(query, 1000, searchEntityTypes);
             }
 
             public void onSuccess() {


### PR DESCRIPTION
Okay so the defect flagged as regression for the search fields functionality:
![image](https://user-images.githubusercontent.com/30106237/37963720-d369a3e6-31c7-11e8-856c-b2f0725d29d2.png)

As i have seen the issue was that the retrieved entity count was off, we had limited to 20 entities per entity type, but in octane there is no limitation ( or it is higher limit) either way i have found that changing the limit to a reasonably large number retrieves the correct amount of entities per type. Thus the defect being fixed