### PR TITLE
search field is cleared when all, none or reset button is pressed

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/FieldsSelectFrame.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/FieldsSelectFrame.java
@@ -99,6 +99,7 @@ public class FieldsSelectFrame extends JFrame {
         selectNoneButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
+                clearSearchField();
                 noneButtonClicked();
             }
         });
@@ -108,6 +109,7 @@ public class FieldsSelectFrame extends JFrame {
         selectAllButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
+                clearSearchField();
                 allButtonClicked();
             }
         });
@@ -116,6 +118,7 @@ public class FieldsSelectFrame extends JFrame {
         resetButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
+                clearSearchField();
                 resetButtonClicked();
             }
         });
@@ -189,6 +192,10 @@ public class FieldsSelectFrame extends JFrame {
         setAlwaysOnTop(true);
         setUndecorated(true);
         pack();
+    }
+
+    private void clearSearchField(){
+        searchField.setText("");
     }
 
     private void noneButtonClicked() {


### PR DESCRIPTION
 [Defect](https://octane-center.saas.hpe.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=605078)

The defect as i've seen refers to the fact that after pressing the all, none or reset button the text in the searchfield should restrict the results but it does not. 

From my perspective there should be an action triggered when those buttons are pressed to clear the search fields results. 