### PR TITLE
Connection error and default_taxonomies

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/settings/ConnectionSettingsConfigurable.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/settings/ConnectionSettingsConfigurable.java
@@ -238,7 +238,7 @@ public class ConnectionSettingsConfigurable implements SearchableConfigurable, C
                     if (ex.getMessage().contains("401")) {
                         connectionSettingsView.setConnectionStatusError("Invalid username or password.");
                     } else {
-                        connectionSettingsView.setConnectionStatusError(ex.getMessage());
+                        connectionSettingsView.setConnectionStatusError("Failed to connect to octane, please check your server url.");
                     }
             });
             return null;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/EntityDetailView.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/EntityDetailView.java
@@ -87,7 +87,7 @@ public class EntityDetailView extends JPanel implements View, Scrollable {
         gridBagLayout.columnWidths = new int[]{0, 0, 0};
         gridBagLayout.rowHeights = new int[]{0, 0, 0, 0, 0};
         gridBagLayout.columnWeights = new double[]{1.0, 0.0, Double.MIN_VALUE};
-        gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 1.0, Double.MIN_VALUE};
+        gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 1.0, Double.MIN_VALUE};
         setLayout(gridBagLayout);
 
         Color separatorColor = UIManager.getColor("Separator.foreground");

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/field/FieldEditorFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/field/FieldEditorFactory.java
@@ -57,7 +57,7 @@ public class FieldEditorFactory {
         if (!fieldMetadata.isEditable() ||
                 fieldMetadata.isFinal() ||
                 fieldName.equals(DetailsViewDefaultFields.FIELD_APPMODULE) ||
-                fieldName.equals(DetailsViewDefaultFields.FIELD_ENVIROMENT)) {
+                fieldName.contains(DetailsViewDefaultFields.FIELD_ENVIROMENT)) {
             fieldEditor = new ReadOnlyFieldEditor();
         } else {
             switch (fieldMetadata.getFieldType()) {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/field/FieldEditorFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/field/FieldEditorFactory.java
@@ -54,10 +54,10 @@ public class FieldEditorFactory {
         FieldEditor fieldEditor = null;
 
         //EntityFieldsConstants.FIELD_APPMODULE is a wannabe tree, need to make special ui for it
-        if (!fieldMetadata.isEditable() ||
-                fieldMetadata.isFinal() ||
-                fieldName.equals(DetailsViewDefaultFields.FIELD_APPMODULE) ||
-                fieldName.contains(DetailsViewDefaultFields.FIELD_ENVIROMENT)) {
+        if (!fieldMetadata.isEditable() || fieldMetadata.isFinal()) {
+            fieldEditor = new ReadOnlyFieldEditor();
+        } else if((entityModelWrapper.getEntityType()==Entity.MANUAL_TEST_RUN || entityModelWrapper.getEntityType() == Entity.TEST_SUITE_RUN) &&
+                (fieldName.equals(DetailsViewDefaultFields.FIELD_APPMODULE) || fieldName.contains(DetailsViewDefaultFields.FIELD_ENVIROMENT))) {
             fieldEditor = new ReadOnlyFieldEditor();
         } else {
             switch (fieldMetadata.getFieldType()) {


### PR DESCRIPTION
- masks the errors received upon connecting under a nicer error message
- removes default_taxonomies field for the same reason as taxonomies were removed, should be editable only from octane