### PR TITLE
Dynamic entity labels

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/PluginModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/PluginModule.java
@@ -107,7 +107,7 @@ public class PluginModule extends AbstractModule {
     @Provides
     @Named("searchEntityTreeView")
     public EntityTreeView getSearchEntityTreeView() {
-        EntityTreeView entityTreeView = new EntityTreeView(new SearchResultEntityTreeCellRenderer());
+        EntityTreeView entityTreeView = new EntityTreeView(getInstance(SearchResultEntityTreeCellRenderer.class));
         injectorSupplier.get().injectMembers(entityTreeView);
         return entityTreeView;
     }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/ToolbarActiveItem.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/ToolbarActiveItem.java
@@ -18,6 +18,7 @@ import com.hpe.adm.octane.ideplugins.intellij.PluginModule;
 import com.hpe.adm.octane.ideplugins.intellij.gitcommit.CommitMessageUtils;
 import com.hpe.adm.octane.ideplugins.intellij.settings.IdePluginPersistentState;
 import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactory;
+import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryManager;
 import com.hpe.adm.octane.ideplugins.services.util.PartialEntity;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.project.Project;
@@ -37,7 +38,9 @@ import java.util.Map;
 
 public class ToolbarActiveItem {
 
-    private static EntityIconFactory entityIconFactory = new EntityIconFactory(20, 20, 10, Color.WHITE);
+    @Inject
+    private EntityIconFactoryManager factoryManager;
+
     private static Map<Project, Runnable> activeItemClickHandlers = new HashMap<>();
     private ActiveItemAction activeItemAction;
     private CopyCommitMessageAction copyCommitMessageAction;
@@ -91,7 +94,8 @@ public class ToolbarActiveItem {
             presentation.setDescription(partialEntity.getEntityName());
             presentation.setText("");
             presentation.setText("#" + partialEntity.getEntityId());
-            presentation.setIcon(new ImageIcon(entityIconFactory.getIconAsImage(partialEntity.getEntityType())));
+            EntityIconFactory iconFactory = factoryManager.getEntityIconFactory(20, 10);
+            presentation.setIcon(new ImageIcon(iconFactory.getIconAsImage(partialEntity.getEntityType())));
         }
 
         @Override

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/HeaderPanel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/HeaderPanel.java
@@ -21,6 +21,7 @@ import com.hpe.adm.nga.sdk.model.StringFieldModel;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.hpe.adm.octane.ideplugins.intellij.ui.detail.DetailsViewDefaultFields;
 import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactory;
+import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryManager;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.model.EntityModelWrapper;
 import com.hpe.adm.octane.ideplugins.services.util.Util;
@@ -62,6 +63,9 @@ public class HeaderPanel extends JPanel {
 
     @Inject
     private EntityService entityService;
+
+    @Inject
+    private EntityIconFactoryManager factoryManager;
 
     @Inject
     public HeaderPanel(PhasePanel phasePanel) {
@@ -259,7 +263,7 @@ public class HeaderPanel extends JPanel {
 
     public void setEntityModel(EntityModelWrapper entityModelWrapper) {
         this.entityModelWrapper = entityModelWrapper;
-        EntityIconFactory entityIconFactory = new EntityIconFactory(26, 26, 12);
+        EntityIconFactory entityIconFactory = factoryManager.getEntityIconFactory(26, 12);
         // icon
         setEntityIcon(new ImageIcon(entityIconFactory.getIconAsImage(entityModelWrapper.getEntityType())));
         // id

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactory.java
@@ -100,7 +100,6 @@ public class EntityIconFactory {
 
     private JComponent createIconAsComponent(Entity entity) {
         //Make the label
-        Font defaultFont = new JXLabel().getFont();
         JXLabel label = new JXLabel(new ImageIcon(createIconAsImage(entity)));
         label.setPreferredSize(new Dimension(iconWidth, iconHeight));
         label.setMinimumSize(new Dimension(iconWidth, iconHeight));

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactory.java
@@ -13,7 +13,9 @@
 
 package com.hpe.adm.octane.ideplugins.intellij.ui.entityicon;
 
+import com.hpe.adm.nga.sdk.model.EntityModel;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
+import com.hpe.adm.octane.ideplugins.services.EntityLabelService;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.intellij.util.ImageLoader;
 import org.jdesktop.swingx.JXLabel;
@@ -29,6 +31,8 @@ public class EntityIconFactory {
     //Detail for unmapped entity type
     private final IconDetail unmapedEntityIconDetail = new IconDetail(new Color(0, 0, 0, 0), "", true);
 
+    private final String INITIALS = "initials";
+
     //map to color and short text
     private final Map<Entity, IconDetail> iconDetailMap = new HashMap<>();
     private final Map<Entity, JComponent> iconComponentMap = new HashMap<>();
@@ -38,21 +42,16 @@ public class EntityIconFactory {
     private Color fontColor = new Color(255, 255, 255);
     private int fontSize = 15;
 
+    private EntityLabelService entityLabelService;
+
     private static final Image activeImg = ImageLoader.loadFromResource(Constants.IMG_ACTIVE_ITEM);
 
     public EntityIconFactory() {
         init();
     }
 
-    public EntityIconFactory(int iconHeight, int iconWidth, int fontSize, Color fontColor) {
-        this.iconHeight = iconHeight;
-        this.iconWidth = iconWidth;
-        this.fontColor = fontColor;
-        this.fontSize = fontSize;
-        init();
-    }
-
-    public EntityIconFactory(int iconHeight, int iconWidth, int fontSize) {
+    public EntityIconFactory(EntityLabelService entityLabelService, int iconHeight, int iconWidth, int fontSize) {
+        this.entityLabelService = entityLabelService;
         this.iconHeight = iconHeight;
         this.iconWidth = iconWidth;
         this.fontSize = fontSize;
@@ -60,24 +59,41 @@ public class EntityIconFactory {
     }
 
     private void init() {
-        iconDetailMap.put(Entity.USER_STORY, new IconDetail(new Color(255, 176, 0), "US"));
-        iconDetailMap.put(Entity.QUALITY_STORY, new IconDetail(new Color(51, 193, 128), "QS"));
-        iconDetailMap.put(Entity.DEFECT, new IconDetail(new Color(178, 22, 70), "D"));
-        iconDetailMap.put(Entity.EPIC, new IconDetail(new Color(116, 37, 173), "E"));
-        iconDetailMap.put(Entity.FEATURE, new IconDetail(new Color(229, 120, 40), "F"));
+        Map<String, EntityModel> entityLabels = entityLabelService.getEntityLabelDetails();
 
-        iconDetailMap.put(Entity.TASK, new IconDetail(new Color(22, 104, 193), "T"));
+        iconDetailMap.put(Entity.USER_STORY, new IconDetail(new Color(255, 176, 0),
+                entityLabels.get(Entity.USER_STORY.getSubtypeName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.QUALITY_STORY, new IconDetail(new Color(51, 193, 128),
+                entityLabels.get(Entity.QUALITY_STORY.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.DEFECT, new IconDetail(new Color(178, 22, 70),
+                entityLabels.get(Entity.DEFECT.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.EPIC, new IconDetail(new Color(116, 37, 173),
+                entityLabels.get(Entity.EPIC.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.FEATURE, new IconDetail(new Color(229, 120, 40),
+                entityLabels.get(Entity.FEATURE.getEntityName()).getValue(INITIALS).getValue().toString()));
 
-        iconDetailMap.put(Entity.MANUAL_TEST, new IconDetail(new Color(0, 171, 243), "MT"));
-        iconDetailMap.put(Entity.GHERKIN_TEST, new IconDetail(new Color(0, 169, 137), "GT"));
+        iconDetailMap.put(Entity.TASK, new IconDetail(new Color(22, 104, 193),
+                entityLabels.get(Entity.TASK.getEntityName()).getValue(INITIALS).getValue().toString()));
 
-        iconDetailMap.put(Entity.TEST_SUITE, new IconDetail(new Color(39, 23, 130), "TS"));
-        iconDetailMap.put(Entity.MANUAL_TEST_RUN, new IconDetail(new Color(0, 171, 243), "MR"));
-        iconDetailMap.put(Entity.TEST_SUITE_RUN, new IconDetail(new Color(0, 171, 243), "SR"));
-        iconDetailMap.put(Entity.AUTOMATED_TEST, new IconDetail(new Color(186, 71, 226), "AT"));
+        iconDetailMap.put(Entity.MANUAL_TEST, new IconDetail(new Color(0, 171, 243),
+                entityLabels.get(Entity.MANUAL_TEST.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.GHERKIN_TEST, new IconDetail(new Color(0, 169, 137),
+                entityLabels.get(Entity.GHERKIN_TEST.getEntityName()).getValue(INITIALS).getValue().toString()));
 
-        iconDetailMap.put(Entity.COMMENT, new IconDetail(new Color(253, 225, 89), "C"));
-        iconDetailMap.put(Entity.REQUIREMENT, new IconDetail(new Color(11, 142, 172), "R"));
+        iconDetailMap.put(Entity.TEST_SUITE, new IconDetail(new Color(39, 23, 130),
+                entityLabels.get(Entity.TEST_SUITE.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.MANUAL_TEST_RUN, new IconDetail(new Color(0, 171, 243),
+                entityLabels.get(Entity.MANUAL_TEST_RUN.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.TEST_SUITE_RUN, new IconDetail(new Color(0, 171, 243),
+                entityLabels.get(Entity.TEST_SUITE_RUN.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.AUTOMATED_TEST, new IconDetail(new Color(186, 71, 226),
+                entityLabels.get(Entity.AUTOMATED_TEST.getEntityName()).getValue(INITIALS).getValue().toString()));
+
+
+        iconDetailMap.put(Entity.COMMENT, new IconDetail(new Color(253, 225, 89),
+                entityLabels.get(Entity.COMMENT.getEntityName()).getValue(INITIALS).getValue().toString()));
+        iconDetailMap.put(Entity.REQUIREMENT, new IconDetail(new Color(11, 142, 172),
+                entityLabels.get(Entity.REQUIREMENT.getTypeName()).getValue(INITIALS).getValue().toString()));
 
         iconDetailMap.keySet().forEach(entity -> iconComponentMap.put(entity, createIconAsComponent(entity)));
     }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactoryManager.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactoryManager.java
@@ -27,18 +27,22 @@ public class EntityIconFactoryManager {
     @Inject
     private EntityLabelService entityLabelService;
 
-    private Map<Integer, EntityIconFactory> factories;
+    private Map<Integer, Map<Integer, EntityIconFactory>> factories;
 
     public EntityIconFactoryManager() {
         factories = new HashMap<>();
     }
 
-    public EntityIconFactory getEntityIconFactory(int size) {
+    public EntityIconFactory getEntityIconFactory(int size, int fontSize) {
         if (factories.get(size) == null) {
-            //todo create another factory and add it to the pool of factories
+            Map<Integer, EntityIconFactory> factoryFontList = new HashMap<>();
+            factoryFontList.put(fontSize, new EntityIconFactory(entityLabelService, size, size, fontSize));
+            factories.put(size, factoryFontList);
         }
-
-        return factories.get(size);
+        if (factories.get(size).get(fontSize) == null) {
+            factories.get(size).put(fontSize, new EntityIconFactory(entityLabelService, size, size, fontSize));
+        }
+        return factories.get(size).get(fontSize);
     }
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactoryManager.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactoryManager.java
@@ -1,0 +1,45 @@
+/*
+ * © 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.hpe.adm.octane.ideplugins.intellij.ui.entityicon;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hpe.adm.octane.ideplugins.services.EntityLabelService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Singleton
+public class EntityIconFactoryManager {
+
+    @Inject
+    private EntityLabelService entityLabelService;
+
+    private Map<Integer, EntityIconFactory> factories;
+
+    public EntityIconFactoryManager() {
+        factories = new HashMap<>();
+    }
+
+    public EntityIconFactory getEntityIconFactory(int size) {
+        if (factories.get(size) == null) {
+            //todo create another factory and add it to the pool of factories
+        }
+
+        return factories.get(size);
+    }
+
+
+}

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
@@ -22,6 +22,7 @@ import com.hpe.adm.octane.ideplugins.intellij.eventbus.RefreshMyWorkEvent;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Presenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactory;
+import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryManager;
 import com.hpe.adm.octane.ideplugins.intellij.ui.tabbedpane.TabbedPanePresenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityCategory;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityTreeModel;
@@ -44,7 +45,6 @@ import com.intellij.openapi.util.IconLoader;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -55,7 +55,8 @@ import static com.hpe.adm.octane.ideplugins.services.util.Util.getUiDataFromMode
 
 public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
 
-    private static final EntityIconFactory entityIconFactory = new EntityIconFactory(20, 20, 11, Color.WHITE);
+    @Inject
+    private EntityIconFactoryManager factoryManager;
 
     private static final Entity[] searchEntityTypes = new Entity[]{
             Entity.EPIC,
@@ -88,11 +89,11 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
         return entityTreeView;
     }
 
-    public void globalSearch(String query){
+    public void globalSearch(String query) {
 
         lastSearchQuery = query;
 
-        Task.Backgroundable backgroundTask = new Task.Backgroundable(null, "Searching Octane for \""+query+"\"", false) {
+        Task.Backgroundable backgroundTask = new Task.Backgroundable(null, "Searching Octane for \"" + query + "\"", false) {
 
             private Collection<EntityModel> searchResults;
 
@@ -144,7 +145,7 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
         entityTreeView.setComponentWhenEmpty(() -> new NoSearchResultsPanel());
     }
 
-    private EntityTreeModel createEmptyEntityTreeModel(Collection<EntityModel> entityModels){
+    private EntityTreeModel createEmptyEntityTreeModel(Collection<EntityModel> entityModels) {
         List<EntityCategory> entityCategories = new ArrayList<>();
         entityCategories.add(new SearchEntityCategory("Backlog", Entity.USER_STORY, Entity.EPIC, Entity.FEATURE, Entity.QUALITY_STORY));
         entityCategories.add(new SearchEntityCategory("Requirements", Entity.REQUIREMENT));
@@ -176,7 +177,8 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
             });
             popup.add(viewInBrowserItem);
 
-            if(TabbedPanePresenter.isDetailTabSupported(entityType)){
+            if (TabbedPanePresenter.isDetailTabSupported(entityType)) {
+                EntityIconFactory entityIconFactory = factoryManager.getEntityIconFactory(20, 11);
                 Icon icon = new ImageIcon(entityIconFactory.getIconAsImage(entityType));
                 JMenuItem viewDetailMenuItem = new JMenuItem("View details", icon);
                 viewDetailMenuItem.addMouseListener(new MouseAdapter() {
@@ -188,7 +190,7 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
                 popup.add(viewDetailMenuItem);
             }
 
-            if(myWorkService.isAddingToMyWorkSupported(entityType)) {
+            if (myWorkService.isAddingToMyWorkSupported(entityType)) {
                 JMenuItem addToMyWorkMenuItem = new JMenuItem("Add to \"My Work\"", AllIcons.General.Add);
                 addToMyWorkMenuItem.addMouseListener(new MouseAdapter() {
                     @Override
@@ -196,7 +198,7 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
                         ApplicationManager.getApplication().invokeLater(() -> {
                             Task.Backgroundable backgroundTask = new Task.Backgroundable(null, "Adding item to \"My Work\"", true) {
                                 public void run(@NotNull ProgressIndicator indicator) {
-                                    if(myWorkService.addToMyWork(entityModel)) {
+                                    if (myWorkService.addToMyWork(entityModel)) {
                                         eventBus.post(new RefreshMyWorkEvent());
                                         UiUtil.showWarningBalloon(null,
                                                 "Item added",

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
@@ -29,6 +29,7 @@ import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityTreeModel;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityTreeView;
 import com.hpe.adm.octane.ideplugins.intellij.ui.util.UiUtil;
 import com.hpe.adm.octane.ideplugins.intellij.util.ExceptionHandler;
+import com.hpe.adm.octane.ideplugins.services.EntityLabelService;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.mywork.MyWorkService;
@@ -50,6 +51,7 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static com.hpe.adm.octane.ideplugins.services.util.Util.getUiDataFromModel;
 
@@ -57,6 +59,9 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
 
     @Inject
     private EntityIconFactoryManager factoryManager;
+
+    @Inject
+    private EntityLabelService entityLabelService;
 
     private static final Entity[] searchEntityTypes = new Entity[]{
             Entity.EPIC,
@@ -147,10 +152,11 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
 
     private EntityTreeModel createEmptyEntityTreeModel(Collection<EntityModel> entityModels) {
         List<EntityCategory> entityCategories = new ArrayList<>();
+        Map<String, EntityModel> entityLabelMap = entityLabelService.getEntityLabelDetails();
         entityCategories.add(new SearchEntityCategory("Backlog", Entity.USER_STORY, Entity.EPIC, Entity.FEATURE, Entity.QUALITY_STORY));
-        entityCategories.add(new SearchEntityCategory("Requirements", Entity.REQUIREMENT));
-        entityCategories.add(new SearchEntityCategory("Defects", Entity.DEFECT));
-        entityCategories.add(new SearchEntityCategory("Tasks", Entity.TASK));
+        entityCategories.add(new SearchEntityCategory(entityLabelMap.get(Entity.REQUIREMENT.getTypeName()).getValue("plural_capitalized").getValue().toString(), Entity.REQUIREMENT));
+        entityCategories.add(new SearchEntityCategory(entityLabelMap.get(Entity.DEFECT.getEntityName()).getValue("plural_capitalized").getValue().toString(), Entity.DEFECT));
+        entityCategories.add(new SearchEntityCategory(entityLabelMap.get(Entity.TASK.getEntityName()).getValue("plural_capitalized").getValue().toString(), Entity.TASK));
         entityCategories.add(new SearchEntityCategory("Tests", Entity.TEST_SUITE, Entity.MANUAL_TEST, Entity.AUTOMATED_TEST, Entity.GHERKIN_TEST));
         EntityTreeModel model = new EntityTreeModel(entityCategories, entityModels);
         return model;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/SearchEntityModelRow.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/SearchEntityModelRow.java
@@ -13,7 +13,9 @@
 
 package com.hpe.adm.octane.ideplugins.intellij.ui.searchresult;
 
+import com.google.inject.Inject;
 import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactory;
+import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryManager;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.intellij.util.ui.UIUtil;
 import org.jdesktop.swingx.JXLabel;
@@ -21,28 +23,28 @@ import org.jdesktop.swingx.JXLabel;
 import javax.swing.*;
 import java.awt.*;
 
-public class SearchEntityModelRow extends JPanel{
+public class SearchEntityModelRow extends JPanel {
+    @Inject
+    private EntityIconFactoryManager factoryManager;
 
-	private static final long serialVersionUID = 1L;
-	private JXLabel lblEntityName;
-	private JPanel panelIcon;
+    private static final long serialVersionUID = 1L;
+    private JXLabel lblEntityName;
+    private JPanel panelIcon;
 
-	private static final Color transparentColor = new Color(0, 0, 0, 0);
-	private Color fontColor = UIUtil.getLabelFontColor(UIUtil.FontColor.NORMAL);
-	private JXLabel lblEntityRelease;
-
-    private static final EntityIconFactory ENTITY_ICON_FACTORY = new EntityIconFactory(40,40,17,Color.WHITE);
+    private static final Color transparentColor = new Color(0, 0, 0, 0);
+    private Color fontColor = UIUtil.getLabelFontColor(UIUtil.FontColor.NORMAL);
+    private JXLabel lblEntityRelease;
 
     public SearchEntityModelRow() {
+        super();
+    }
+
+    public void initFocusedUI() {
+        fontColor = new Color(255, 255, 255);
         initUI();
     }
 
-	public SearchEntityModelRow(Color fontColor) {
-		this.fontColor = fontColor;
-        initUI();
-	}
-
-	private void initUI(){
+    public void initUI() {
         GridBagLayout gbl_rootPanel = new GridBagLayout();
         gbl_rootPanel.columnWidths = new int[]{0, 150, 0};
         gbl_rootPanel.rowHeights = new int[]{25, 25, 0};
@@ -64,7 +66,7 @@ public class SearchEntityModelRow extends JPanel{
         add(panelIcon, gbc_panelIcon);
         panelIcon.setOpaque(true);
         panelIcon.setBackground(transparentColor);
-        
+
         lblEntityName = new JXLabel("");
         lblEntityName.setForeground(fontColor);
         lblEntityName.setHorizontalAlignment(SwingConstants.LEFT);
@@ -76,7 +78,7 @@ public class SearchEntityModelRow extends JPanel{
         gbc_lblEntityName.gridx = 1;
         gbc_lblEntityName.gridy = 0;
         add(lblEntityName, gbc_lblEntityName);
-        
+
         lblEntityRelease = new JXLabel("");
         lblEntityRelease.setForeground(fontColor);
         lblEntityRelease.setHorizontalAlignment(SwingConstants.LEFT);
@@ -92,21 +94,22 @@ public class SearchEntityModelRow extends JPanel{
         setOpaque(true);
     }
 
-	public void setIcon(Entity entityType, boolean isActive){
-		panelIcon.removeAll();
-		panelIcon.add(ENTITY_ICON_FACTORY.getIconAsComponent(entityType, isActive), BorderLayout.CENTER);
-	}
-	
-	public void setEntityName(String id, String name){
-        lblEntityName.setText("<html><body><b>"+id+"</b>&nbsp;" + name + "</body><html>");
-	}
-	
-	public void setEntityDescription(String description){
+    public void setIcon(Entity entityType, boolean isActive) {
+        panelIcon.removeAll();
+        EntityIconFactory iconFactory = factoryManager.getEntityIconFactory(40, 17);
+        panelIcon.add(iconFactory.getIconAsComponent(entityType, isActive), BorderLayout.CENTER);
+    }
+
+    public void setEntityName(String id, String name) {
+        lblEntityName.setText("<html><body><b>" + id + "</b>&nbsp;" + name + "</body><html>");
+    }
+
+    public void setEntityDescription(String description) {
         lblEntityRelease.setText(description);
     }
 
-    public void setEntityHtmlDescription(String description){
+    public void setEntityHtmlDescription(String description) {
         lblEntityRelease.setText("<html><body>" + description + "</body><html>");
     }
-	
+
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/SearchResultEntityTreeCellRenderer.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/SearchResultEntityTreeCellRenderer.java
@@ -13,6 +13,7 @@
 
 package com.hpe.adm.octane.ideplugins.intellij.ui.searchresult;
 
+import com.google.inject.Inject;
 import com.hpe.adm.nga.sdk.model.EntityModel;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityCategory;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityTreeModel;
@@ -28,6 +29,13 @@ import java.awt.*;
 import static com.hpe.adm.octane.ideplugins.intellij.ui.detail.DetailsViewDefaultFields.FIELD_DESCRIPTION;
 
 public class SearchResultEntityTreeCellRenderer implements TreeCellRenderer {
+
+    @Inject
+    private SearchEntityModelRow rowPanel;
+
+    public SearchResultEntityTreeCellRenderer() {
+        super();
+    }
 
     @Override
     public Component getTreeCellRendererComponent(JTree tree, Object value, boolean selected, boolean expanded, boolean leaf, int row, boolean hasFocus) {
@@ -57,12 +65,10 @@ public class SearchResultEntityTreeCellRenderer implements TreeCellRenderer {
             EntityModel entityModel = (EntityModel) value;
             Long entityId = Long.valueOf(Util.getUiDataFromModel(entityModel.getValue("id")));
 
-            SearchEntityModelRow rowPanel;
-
             if (selected && hasFocus) {
-                rowPanel = new SearchEntityModelRow(new Color(255, 255, 255));
+                rowPanel.initFocusedUI();
             } else {
-                rowPanel = new SearchEntityModelRow();
+                rowPanel.initUI();
             }
 
             rowPanel.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, JBColor.border()));

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/SearchResultEntityTreeCellRenderer.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/SearchResultEntityTreeCellRenderer.java
@@ -15,10 +15,12 @@ package com.hpe.adm.octane.ideplugins.intellij.ui.searchresult;
 
 import com.google.inject.Inject;
 import com.hpe.adm.nga.sdk.model.EntityModel;
+import com.hpe.adm.octane.ideplugins.intellij.PluginModule;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityCategory;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityTreeModel;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.util.Util;
+import com.intellij.openapi.project.Project;
 import com.intellij.ui.JBColor;
 import org.jdesktop.swingx.JXLabel;
 
@@ -31,7 +33,7 @@ import static com.hpe.adm.octane.ideplugins.intellij.ui.detail.DetailsViewDefaul
 public class SearchResultEntityTreeCellRenderer implements TreeCellRenderer {
 
     @Inject
-    private SearchEntityModelRow rowPanel;
+    private Project project;
 
     public SearchResultEntityTreeCellRenderer() {
         super();
@@ -65,6 +67,8 @@ public class SearchResultEntityTreeCellRenderer implements TreeCellRenderer {
             EntityModel entityModel = (EntityModel) value;
             Long entityId = Long.valueOf(Util.getUiDataFromModel(entityModel.getValue("id")));
 
+
+            SearchEntityModelRow rowPanel = PluginModule.getPluginModuleForProject(project).getInstance(SearchEntityModelRow.class);
             if (selected && hasFocus) {
                 rowPanel.initFocusedUI();
             } else {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/tabbedpane/TabbedPanePresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/tabbedpane/TabbedPanePresenter.java
@@ -26,8 +26,8 @@ import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Presenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.ToolbarActiveItem;
 import com.hpe.adm.octane.ideplugins.intellij.ui.detail.EntityDetailPresenter;
-import com.hpe.adm.octane.ideplugins.intellij.ui.detail.EntityDetailView;
 import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactory;
+import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryManager;
 import com.hpe.adm.octane.ideplugins.intellij.ui.searchresult.EntitySearchResultPresenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.searchresult.SearchHistoryManager;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityTreeTablePresenter;
@@ -46,10 +46,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import javax.swing.*;
-import java.awt.*;
 import java.awt.event.KeyEvent;
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.hpe.adm.octane.ideplugins.services.filtering.Entity.*;
 
@@ -72,7 +69,8 @@ public class TabbedPanePresenter implements Presenter<TabbedPaneView> {
         });
     }
 
-    private static EntityIconFactory entityIconFactory = new EntityIconFactory(22, 22, 12, Color.WHITE);
+    @Inject
+    private EntityIconFactoryManager factoryManager;
 
     @Inject
     private SearchHistoryManager searchManager;
@@ -147,7 +145,8 @@ public class TabbedPanePresenter implements Presenter<TabbedPaneView> {
         presenter.setEntity(entityType, entityId);
 
         PartialEntity tabKey = new PartialEntity(entityId, entityName, entityType);
-        ImageIcon tabIcon = new ImageIcon(entityIconFactory.getIconAsImage(entityType));
+        EntityIconFactory iconFactory = factoryManager.getEntityIconFactory(22, 11);
+        ImageIcon tabIcon = new ImageIcon(iconFactory.getIconAsImage(entityType));
         TabInfo tabInfo = tabbedPaneView.addTab(
                 String.valueOf(entityId),
                 entityName,

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityModelRow.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityModelRow.java
@@ -13,7 +13,9 @@
 
 package com.hpe.adm.octane.ideplugins.intellij.ui.treetable;
 
+import com.google.inject.Inject;
 import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactory;
+import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryManager;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.intellij.ui.JBColor;
 import com.intellij.util.ui.UIUtil;
@@ -24,181 +26,181 @@ import javax.swing.*;
 import java.awt.*;
 
 public class EntityModelRow extends JPanel {
-	
-    private static final EntityIconFactory entityIconFactory = new EntityIconFactory(40,40,17,Color.WHITE);
+
+    @Inject
+    private EntityIconFactoryManager factoryManager;
 
     private Color fontColor = UIUtil.getLabelFontColor(UIUtil.FontColor.NORMAL);
-	private JPanel panelEntityIcon;
-	private JXLabel lblEntityId;
-	private JXLabel lblTitle;
-	private JXLabel lblSubtitle;
-	private JPanel panelDetailsTop;
-	private JPanel panelDetailsBottom;
-	
-	public EntityModelRow() {
-		 initUi();
-	}
-	
-	public EntityModelRow(Color fontColor) {
-		 this.fontColor = fontColor;
-		 initUi();
-	}
-	
-	private void initUi(){
-		GridBagLayout gridBagLayout = new GridBagLayout();
-		gridBagLayout.columnWidths = new int[]{40, 150, 0, 0};
-		gridBagLayout.rowHeights = new int[]{50, 0};
-		gridBagLayout.columnWeights = new double[]{0.0, 1.0, 0.0, Double.MIN_VALUE};
-		gridBagLayout.rowWeights = new double[]{0.0, Double.MIN_VALUE};
-		setLayout(gridBagLayout);
-		
-		panelEntityIcon = new JPanel();
-		panelEntityIcon.setOpaque(false);
-		panelEntityIcon.setMinimumSize(new Dimension(40, 40));
-		panelEntityIcon.setPreferredSize(new Dimension(40, 40));
-		panelEntityIcon.setMaximumSize(new Dimension(40, 40));
-		GridBagConstraints gbc_panelEntityIcon = new GridBagConstraints();
-		gbc_panelEntityIcon.fill = GridBagConstraints.BOTH;
-		gbc_panelEntityIcon.insets = new Insets(0, 0, 0, 5);
-		gbc_panelEntityIcon.gridx = 0;
-		gbc_panelEntityIcon.gridy = 0;
-		add(panelEntityIcon, gbc_panelEntityIcon);
-		panelEntityIcon.setLayout(new FlowLayout(FlowLayout.CENTER, 5, 5));
-		
-		JPanel panelEntityTitle = new JPanel();
-		panelEntityTitle.setOpaque(false);
-		GridBagConstraints gbc_panelEntityTitle = new GridBagConstraints();
-		gbc_panelEntityTitle.fill = GridBagConstraints.BOTH;
-		gbc_panelEntityTitle.insets = new Insets(0, 0, 0, 5);
-		gbc_panelEntityTitle.gridx = 1;
-		gbc_panelEntityTitle.gridy = 0;
-		add(panelEntityTitle, gbc_panelEntityTitle);
-		GridBagLayout gbl_panelEntityTitle = new GridBagLayout();
-		gbl_panelEntityTitle.columnWidths = new int[]{0, 0, 0};
-		gbl_panelEntityTitle.rowHeights = new int[]{0, 0, 0};
-		gbl_panelEntityTitle.columnWeights = new double[]{0.0, 1.0, Double.MIN_VALUE};
-		gbl_panelEntityTitle.rowWeights = new double[]{1.0, 1.0, Double.MIN_VALUE};
-		panelEntityTitle.setLayout(gbl_panelEntityTitle);
-		
-		lblEntityId = createLabel("");
-		GridBagConstraints gbc_lblEntityId = new GridBagConstraints();
-		gbc_lblEntityId.insets = new Insets(5, 0, 3, 5);
-		gbc_lblEntityId.gridx = 0;
-		gbc_lblEntityId.gridy = 0;
-		panelEntityTitle.add(lblEntityId, gbc_lblEntityId);
-		
-		lblTitle = createLabel("");
-		GridBagConstraints gbc_lblTitle = new GridBagConstraints();
-		gbc_lblTitle.insets = new Insets(5, 0, 3, 0);
-		gbc_lblTitle.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblTitle.gridx = 1;
-		gbc_lblTitle.gridy = 0;
-		panelEntityTitle.add(lblTitle, gbc_lblTitle);
-		
-		lblSubtitle = createLabel("");
-		GridBagConstraints gbc_lblSubtitle = new GridBagConstraints();
-		gbc_lblSubtitle.insets = new Insets(0, 0, 5, 0);
-		gbc_lblSubtitle.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblSubtitle.gridwidth = 2;
-		gbc_lblSubtitle.gridx = 0;
-		gbc_lblSubtitle.gridy = 1;
-		panelEntityTitle.add(lblSubtitle, gbc_lblSubtitle);
-		
-		JPanel panelEntityDetails = new JPanel();
-		panelEntityDetails.setOpaque(false);
-		GridBagConstraints gbc_panelEntityDetails = new GridBagConstraints();
-		gbc_panelEntityDetails.insets = new Insets(0, 0, 0, 15);
-		gbc_panelEntityDetails.fill = GridBagConstraints.BOTH;
-		gbc_panelEntityDetails.gridx = 2;
-		gbc_panelEntityDetails.gridy = 0;
-		add(panelEntityDetails, gbc_panelEntityDetails);
-		GridBagLayout gbl_panelEntityDetails = new GridBagLayout();
-		gbl_panelEntityDetails.columnWidths = new int[]{0, 0};
-		gbl_panelEntityDetails.rowHeights = new int[]{0, 0, 0};
-		gbl_panelEntityDetails.columnWeights = new double[]{1.0, Double.MIN_VALUE};
-		gbl_panelEntityDetails.rowWeights = new double[]{1.0, 1.0, Double.MIN_VALUE};
-		panelEntityDetails.setLayout(gbl_panelEntityDetails);
-		
-		panelDetailsTop = new JPanel();
-		panelDetailsTop.setOpaque(false);
-		FlowLayout flowLayout_1 = (FlowLayout) panelDetailsTop.getLayout();
-		flowLayout_1.setVgap(0);
-		flowLayout_1.setAlignment(FlowLayout.TRAILING);
-		GridBagConstraints gbc_panelDetailsTop = new GridBagConstraints();
-		gbc_panelDetailsTop.insets = new Insets(5, 0, 3, 0);
-		gbc_panelDetailsTop.fill = GridBagConstraints.BOTH;
-		gbc_panelDetailsTop.gridx = 0;
-		gbc_panelDetailsTop.gridy = 0;
-		panelEntityDetails.add(panelDetailsTop, gbc_panelDetailsTop);
-		
-		panelDetailsBottom = new JPanel();
-		panelDetailsBottom.setOpaque(false);
-		FlowLayout flowLayout = (FlowLayout) panelDetailsBottom.getLayout();
-		flowLayout.setVgap(0);
-		flowLayout.setAlignment(FlowLayout.TRAILING);
-		GridBagConstraints gbc_panelDetailsBottom = new GridBagConstraints();
-		gbc_panelDetailsBottom.insets = new Insets(0, 0, 5, 0);
-		gbc_panelDetailsBottom.fill = GridBagConstraints.BOTH;
-		gbc_panelDetailsBottom.gridx = 0;
-		gbc_panelDetailsBottom.gridy = 1;
-		panelEntityDetails.add(panelDetailsBottom, gbc_panelDetailsBottom);
-	}
-	
-    public void setIcon(Entity entityType, boolean isActive){
+    private JPanel panelEntityIcon;
+    private JXLabel lblEntityId;
+    private JXLabel lblTitle;
+    private JXLabel lblSubtitle;
+    private JPanel panelDetailsTop;
+    private JPanel panelDetailsBottom;
+
+    public EntityModelRow() {
+        super();
+    }
+
+    public void initFocusedUI() {
+        this.fontColor = new Color(255, 255, 255);
+        initUI();
+    }
+
+    public void initUI() {
+        GridBagLayout gridBagLayout = new GridBagLayout();
+        gridBagLayout.columnWidths = new int[]{40, 150, 0, 0};
+        gridBagLayout.rowHeights = new int[]{50, 0};
+        gridBagLayout.columnWeights = new double[]{0.0, 1.0, 0.0, Double.MIN_VALUE};
+        gridBagLayout.rowWeights = new double[]{0.0, Double.MIN_VALUE};
+        setLayout(gridBagLayout);
+
+        panelEntityIcon = new JPanel();
+        panelEntityIcon.setOpaque(false);
+        panelEntityIcon.setMinimumSize(new Dimension(40, 40));
+        panelEntityIcon.setPreferredSize(new Dimension(40, 40));
+        panelEntityIcon.setMaximumSize(new Dimension(40, 40));
+        GridBagConstraints gbc_panelEntityIcon = new GridBagConstraints();
+        gbc_panelEntityIcon.fill = GridBagConstraints.BOTH;
+        gbc_panelEntityIcon.insets = new Insets(0, 0, 0, 5);
+        gbc_panelEntityIcon.gridx = 0;
+        gbc_panelEntityIcon.gridy = 0;
+        add(panelEntityIcon, gbc_panelEntityIcon);
+        panelEntityIcon.setLayout(new FlowLayout(FlowLayout.CENTER, 5, 5));
+
+        JPanel panelEntityTitle = new JPanel();
+        panelEntityTitle.setOpaque(false);
+        GridBagConstraints gbc_panelEntityTitle = new GridBagConstraints();
+        gbc_panelEntityTitle.fill = GridBagConstraints.BOTH;
+        gbc_panelEntityTitle.insets = new Insets(0, 0, 0, 5);
+        gbc_panelEntityTitle.gridx = 1;
+        gbc_panelEntityTitle.gridy = 0;
+        add(panelEntityTitle, gbc_panelEntityTitle);
+        GridBagLayout gbl_panelEntityTitle = new GridBagLayout();
+        gbl_panelEntityTitle.columnWidths = new int[]{0, 0, 0};
+        gbl_panelEntityTitle.rowHeights = new int[]{0, 0, 0};
+        gbl_panelEntityTitle.columnWeights = new double[]{0.0, 1.0, Double.MIN_VALUE};
+        gbl_panelEntityTitle.rowWeights = new double[]{1.0, 1.0, Double.MIN_VALUE};
+        panelEntityTitle.setLayout(gbl_panelEntityTitle);
+
+        lblEntityId = createLabel("");
+        GridBagConstraints gbc_lblEntityId = new GridBagConstraints();
+        gbc_lblEntityId.insets = new Insets(5, 0, 3, 5);
+        gbc_lblEntityId.gridx = 0;
+        gbc_lblEntityId.gridy = 0;
+        panelEntityTitle.add(lblEntityId, gbc_lblEntityId);
+
+        lblTitle = createLabel("");
+        GridBagConstraints gbc_lblTitle = new GridBagConstraints();
+        gbc_lblTitle.insets = new Insets(5, 0, 3, 0);
+        gbc_lblTitle.fill = GridBagConstraints.HORIZONTAL;
+        gbc_lblTitle.gridx = 1;
+        gbc_lblTitle.gridy = 0;
+        panelEntityTitle.add(lblTitle, gbc_lblTitle);
+
+        lblSubtitle = createLabel("");
+        GridBagConstraints gbc_lblSubtitle = new GridBagConstraints();
+        gbc_lblSubtitle.insets = new Insets(0, 0, 5, 0);
+        gbc_lblSubtitle.fill = GridBagConstraints.HORIZONTAL;
+        gbc_lblSubtitle.gridwidth = 2;
+        gbc_lblSubtitle.gridx = 0;
+        gbc_lblSubtitle.gridy = 1;
+        panelEntityTitle.add(lblSubtitle, gbc_lblSubtitle);
+
+        JPanel panelEntityDetails = new JPanel();
+        panelEntityDetails.setOpaque(false);
+        GridBagConstraints gbc_panelEntityDetails = new GridBagConstraints();
+        gbc_panelEntityDetails.insets = new Insets(0, 0, 0, 15);
+        gbc_panelEntityDetails.fill = GridBagConstraints.BOTH;
+        gbc_panelEntityDetails.gridx = 2;
+        gbc_panelEntityDetails.gridy = 0;
+        add(panelEntityDetails, gbc_panelEntityDetails);
+        GridBagLayout gbl_panelEntityDetails = new GridBagLayout();
+        gbl_panelEntityDetails.columnWidths = new int[]{0, 0};
+        gbl_panelEntityDetails.rowHeights = new int[]{0, 0, 0};
+        gbl_panelEntityDetails.columnWeights = new double[]{1.0, Double.MIN_VALUE};
+        gbl_panelEntityDetails.rowWeights = new double[]{1.0, 1.0, Double.MIN_VALUE};
+        panelEntityDetails.setLayout(gbl_panelEntityDetails);
+
+        panelDetailsTop = new JPanel();
+        panelDetailsTop.setOpaque(false);
+        FlowLayout flowLayout_1 = (FlowLayout) panelDetailsTop.getLayout();
+        flowLayout_1.setVgap(0);
+        flowLayout_1.setAlignment(FlowLayout.TRAILING);
+        GridBagConstraints gbc_panelDetailsTop = new GridBagConstraints();
+        gbc_panelDetailsTop.insets = new Insets(5, 0, 3, 0);
+        gbc_panelDetailsTop.fill = GridBagConstraints.BOTH;
+        gbc_panelDetailsTop.gridx = 0;
+        gbc_panelDetailsTop.gridy = 0;
+        panelEntityDetails.add(panelDetailsTop, gbc_panelDetailsTop);
+
+        panelDetailsBottom = new JPanel();
+        panelDetailsBottom.setOpaque(false);
+        FlowLayout flowLayout = (FlowLayout) panelDetailsBottom.getLayout();
+        flowLayout.setVgap(0);
+        flowLayout.setAlignment(FlowLayout.TRAILING);
+        GridBagConstraints gbc_panelDetailsBottom = new GridBagConstraints();
+        gbc_panelDetailsBottom.insets = new Insets(0, 0, 5, 0);
+        gbc_panelDetailsBottom.fill = GridBagConstraints.BOTH;
+        gbc_panelDetailsBottom.gridx = 0;
+        gbc_panelDetailsBottom.gridy = 1;
+        panelEntityDetails.add(panelDetailsBottom, gbc_panelDetailsBottom);
+    }
+
+    public void setIcon(Entity entityType, boolean isActive) {
         panelEntityIcon.removeAll();
-        panelEntityIcon.add(entityIconFactory.getIconAsComponent(entityType, isActive), BorderLayout.CENTER);
+        EntityIconFactory iconFactory = factoryManager.getEntityIconFactory(40, 17);
+        panelEntityIcon.add(iconFactory.getIconAsComponent(entityType, isActive), BorderLayout.CENTER);
     }
 
-    public void setEntityName(String id, String name){
-    	lblEntityId.setText(id);
-    	lblTitle.setText("<html><body><span style=\"font-family:'arial unicode ms' , sans-serif\">"+name+"</body></html>");
+    public void setEntityName(String id, String name) {
+        lblEntityId.setText(id);
+        lblTitle.setText("<html><body><span style=\"font-family:'arial unicode ms' , sans-serif\">" + name + "</body></html>");
     }
 
-    public void setEntitySubTitle(String subTitle, String defaultText){
-        if(StringUtils.isEmpty(subTitle)){
+    public void setEntitySubTitle(String subTitle, String defaultText) {
+        if (StringUtils.isEmpty(subTitle)) {
             lblSubtitle.setText(defaultText);
         } else {
-        	lblSubtitle.setText("<html><body><span style=\"font-family:'arial unicode ms' , sans-serif\">"+subTitle+"</body></html>");
+            lblSubtitle.setText("<html><body><span style=\"font-family:'arial unicode ms' , sans-serif\">" + subTitle + "</body></html>");
         }
     }
 
     public enum DetailsPosition {
-    	TOP, BOTTOM
-	}
+        TOP, BOTTOM
+    }
 
-    public void addDetails(String fieldName, String fieldValue, DetailsPosition position){
-    	fieldName = fieldName.trim();
-		if(fieldValue == null || StringUtils.isBlank(fieldValue.trim())){
-			fieldValue = " - ";
-		}
+    public void addDetails(String fieldName, String fieldValue, DetailsPosition position) {
+        fieldName = fieldName.trim();
+        if (fieldValue == null || StringUtils.isBlank(fieldValue.trim())) {
+            fieldValue = " - ";
+        }
 
-		String lblText = "  " + fieldName + ": " + fieldValue;
+        String lblText = "  " + fieldName + ": " + fieldValue;
         JXLabel lbl = createLabel(lblText);
         lbl.setBorder(BorderFactory.createMatteBorder(0, 1, 0, 0, JBColor.border()));
 
-        if(DetailsPosition.TOP.equals(position)){
-			panelDetailsTop.add(lbl);
-		}
-		else if(DetailsPosition.BOTTOM.equals(position)){
-			panelDetailsBottom.add(lbl);
-		}
-    }
-
-    public void addSimpleDetails(String text, DetailsPosition position){
-        JXLabel lbl = createLabel("  " + text);
-        lbl.setBorder(BorderFactory.createMatteBorder(0, 1, 0, 0, JBColor.border()));
-        if(DetailsPosition.TOP.equals(position)){
+        if (DetailsPosition.TOP.equals(position)) {
             panelDetailsTop.add(lbl);
-        }
-        else if(DetailsPosition.BOTTOM.equals(position)){
+        } else if (DetailsPosition.BOTTOM.equals(position)) {
             panelDetailsBottom.add(lbl);
         }
     }
 
-    private JXLabel createLabel(String text){
+    public void addSimpleDetails(String text, DetailsPosition position) {
+        JXLabel lbl = createLabel("  " + text);
+        lbl.setBorder(BorderFactory.createMatteBorder(0, 1, 0, 0, JBColor.border()));
+        if (DetailsPosition.TOP.equals(position)) {
+            panelDetailsTop.add(lbl);
+        } else if (DetailsPosition.BOTTOM.equals(position)) {
+            panelDetailsBottom.add(lbl);
+        }
+    }
+
+    private JXLabel createLabel(String text) {
         JXLabel lbl = new JXLabel(text);
         lbl.setForeground(fontColor);
-        lbl.setFont(new Font("Arial",Font.PLAIN,12));
+        lbl.setFont(new Font("Arial", Font.PLAIN, 12));
         return lbl;
     }
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
@@ -152,7 +152,7 @@ public class EntityTreeCellRenderer implements TreeCellRenderer {
      * @return
      */
     public static Map<Entity, Set<String>> getEntityFieldMap() {
-        return Collections.unmodifiableMap(entityFields); //ok
+        return Collections.unmodifiableMap(entityFields); //tsais
     }
 
     public static String getSubtypeName(String subtype) {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
@@ -16,12 +16,13 @@ package com.hpe.adm.octane.ideplugins.intellij.ui.treetable;
 import com.google.inject.Inject;
 import com.hpe.adm.nga.sdk.model.EntityModel;
 import com.hpe.adm.nga.sdk.model.FieldModel;
+import com.hpe.adm.octane.ideplugins.intellij.PluginModule;
 import com.hpe.adm.octane.ideplugins.intellij.settings.IdePluginPersistentState;
-import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil;
 import com.hpe.adm.octane.ideplugins.services.util.EntityTypeIdPair;
 import com.hpe.adm.octane.ideplugins.services.util.Util;
+import com.intellij.openapi.project.Project;
 import com.intellij.ui.JBColor;
 import org.apache.commons.lang.StringUtils;
 import org.jdesktop.swingx.JXLabel;
@@ -45,6 +46,9 @@ public class EntityTreeCellRenderer implements TreeCellRenderer {
 
     @Inject
     private IdePluginPersistentState idePluginPersistentState;
+
+    @Inject
+    private Project project;
 
     static {
         //US
@@ -187,12 +191,12 @@ public class EntityTreeCellRenderer implements TreeCellRenderer {
             Entity entityType = Entity.getEntityType(entityModel);
             Long entityId = Long.valueOf(getUiDataFromModel(entityModel.getValue("id")));
 
-            //Init row panel
-            final EntityModelRow rowPanel;
+            EntityModelRow rowPanel = PluginModule.getPluginModuleForProject(project).getInstance(EntityModelRow.class);
+
             if (selected && hasFocus) {
-                rowPanel = new EntityModelRow(new Color(255, 255, 255));
+                rowPanel.initFocusedUI();
             } else {
-                rowPanel = new EntityModelRow();
+                rowPanel.initUI();
             }
             rowPanel.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, JBColor.border()));
 
@@ -318,7 +322,7 @@ public class EntityTreeCellRenderer implements TreeCellRenderer {
                 String text = getUiDataFromModel(entityModel.getValue("text"));
                 text = " Comment: " + Util.stripHtml(text);
                 FieldModel owner = getContainerItemForCommentModel(entityModel);
-                if(owner != null){
+                if (owner != null) {
                     String ownerId = getUiDataFromModel(owner, "id");
                     String ownerName = getUiDataFromModel(owner, "name");
                     String ownerType = getUiDataFromModel(owner, "type");

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
@@ -17,6 +17,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.hpe.adm.nga.sdk.model.EntityModel;
+import com.hpe.adm.octane.ideplugins.intellij.PluginModule;
 import com.hpe.adm.octane.ideplugins.intellij.eventbus.OpenDetailTabEvent;
 import com.hpe.adm.octane.ideplugins.intellij.eventbus.RefreshMyWorkEvent;
 import com.hpe.adm.octane.ideplugins.intellij.gitcommit.CommitMessageUtils;
@@ -28,6 +29,7 @@ import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryMan
 import com.hpe.adm.octane.ideplugins.intellij.ui.tabbedpane.TabbedPanePresenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.util.UiUtil;
 import com.hpe.adm.octane.ideplugins.intellij.util.RestUtil;
+import com.hpe.adm.octane.ideplugins.services.EntityLabelService;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.mywork.MyWorkService;
@@ -63,10 +65,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.hpe.adm.octane.ideplugins.services.util.Util.getUiDataFromModel;
@@ -77,6 +76,9 @@ public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
 
     @Inject
     private EntityIconFactoryManager factoryManager;
+
+    @Inject
+    EntityLabelService entityLabelService;
 
     @Inject
     private MyWorkService myWorkService;
@@ -460,12 +462,17 @@ public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
         getView().addEntityKeyHandler(handler);
     }
 
-    private static EntityTreeModel createEntityTreeModel(Collection<EntityModel> entityModels) {
+    private EntityTreeModel createEntityTreeModel(Collection<EntityModel> entityModels) {
         List<EntityCategory> entityCategories = new ArrayList<>();
+
+        EntityLabelService entityLabelService = PluginModule.getPluginModuleForProject(project).getInstance(EntityLabelService.class);
+        Map<String, EntityModel> entityLabelMap = entityLabelService.getEntityLabelDetails();
+
+
         entityCategories.add(new UserItemEntityCategory("Backlog", Entity.USER_STORY, Entity.DEFECT, Entity.QUALITY_STORY,
                 Entity.EPIC, Entity.FEATURE));
-        entityCategories.add(new UserItemEntityCategory("Requirements", Entity.REQUIREMENT));
-        entityCategories.add(new UserItemEntityCategory("Tasks", Entity.TASK));
+        entityCategories.add(new UserItemEntityCategory(entityLabelMap.get(Entity.REQUIREMENT.getTypeName()).getValue("plural_capitalized").getValue().toString(), Entity.REQUIREMENT));
+        entityCategories.add(new UserItemEntityCategory(entityLabelMap.get(Entity.TASK.getEntityName()).getValue("plural_capitalized").getValue().toString(), Entity.TASK));
         entityCategories.add(new UserItemEntityCategory("Tests", Entity.GHERKIN_TEST, Entity.MANUAL_TEST));
         entityCategories.add(new UserItemEntityCategory("Mention in comments", Entity.COMMENT));
         entityCategories.add(new UserItemEntityCategory("Runs", Entity.MANUAL_TEST_RUN, Entity.TEST_SUITE_RUN));

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
@@ -24,6 +24,7 @@ import com.hpe.adm.octane.ideplugins.intellij.settings.IdePluginPersistentState;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Presenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactory;
+import com.hpe.adm.octane.ideplugins.intellij.ui.entityicon.EntityIconFactoryManager;
 import com.hpe.adm.octane.ideplugins.intellij.ui.tabbedpane.TabbedPanePresenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.util.UiUtil;
 import com.hpe.adm.octane.ideplugins.intellij.util.RestUtil;
@@ -58,9 +59,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 
 import javax.swing.*;
-import java.awt.*;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.*;
@@ -75,9 +73,10 @@ import static com.hpe.adm.octane.ideplugins.services.util.Util.getUiDataFromMode
 
 public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
 
-    private static final EntityIconFactory entityIconFactory = new EntityIconFactory(20, 20, 11, Color.WHITE);
-
     private EntityTreeView entityTreeTableView;
+
+    @Inject
+    private EntityIconFactoryManager factoryManager;
 
     @Inject
     private MyWorkService myWorkService;
@@ -221,8 +220,10 @@ public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
             });
             popup.add(viewInBrowserItem);
 
+            EntityIconFactory iconFactory = factoryManager.getEntityIconFactory(20, 11);
+
             if (TabbedPanePresenter.isDetailTabSupported(entityType)) {
-                Icon icon = new ImageIcon(entityIconFactory.getIconAsImage(entityType));
+                Icon icon = new ImageIcon(iconFactory.getIconAsImage(entityType));
                 JMenuItem viewDetailMenuItem = new JMenuItem("View details", icon);
                 viewDetailMenuItem.addMouseListener(new MouseAdapter() {
                     @Override
@@ -244,7 +245,7 @@ public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
 
                 if (TabbedPanePresenter.isDetailTabSupported(Entity.getEntityType(parentEntityModel))) {
                     //Add option
-                    Icon icon = new ImageIcon(entityIconFactory.getIconAsImage(Entity.getEntityType(parentEntityModel)));
+                    Icon icon = new ImageIcon(iconFactory.getIconAsImage(Entity.getEntityType(parentEntityModel)));
                     JMenuItem viewParentMenuItem = new JMenuItem("View parent details", icon);
                     viewParentMenuItem.addMouseListener(new MouseAdapter() {
                         @Override


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30106237/45202070-5bc51200-b280-11e8-968b-cb8ca7a5bf6d.png)

If entity labels are changed the plugin will not be aware of this until the next restart, and I think it should be this way due to the following reasons:
- adding an http call to each icon drawing operation slows down the ui creation thread
- adding a check 100% of the times for something that changes in less than 1% of the times is too much of a price to pay performance wise

Let me know if you have any other idea about this