### PR TITLE
defect #711094: Fixes compatibility with IDE version 2016.3, we can't…

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/ToolbarActiveItem.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/ToolbarActiveItem.java
@@ -200,8 +200,8 @@ public class ToolbarActiveItem {
                         "ToolbarRunGroup");
         DefaultActionGroup activeItemActionGroup = new DefaultActionGroup();
 
-        Separator first = Separator.create();
-        activeItemActionGroup.add(first, Constraints.FIRST);
+
+        activeItemActionGroup.addSeparator();
         activeItemActionGroup.add(stopActiveItemAction, Constraints.FIRST);
         activeItemActionGroup.add(copyCommitMessageAction, Constraints.FIRST);
         activeItemActionGroup.add(activeItemAction, Constraints.FIRST);


### PR DESCRIPTION
… go lower than that since the IDE with release version 2016.2 does not contain class ProjectManagerListener which is needed to clean up the actiontoolbar once the project is closed