### PR TITLE
defect #1158079: Fix the title of a comment in my work if the text was too long

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
@@ -341,7 +341,7 @@ public class EntityTreeCellRenderer implements TreeCellRenderer {
                     String ownerName = getUiDataFromModel(owner, "name");
                     String ownerType = getUiDataFromModel(owner, "type");
 
-                    String entityName = wrapHtml("Comment on " + getSubtypeName(ownerType).toLowerCase() + ": " + "<b>" + ownerId + "</b>" + " " + ownerName);
+                    String entityName = getSubtypeName(ownerType) + " " + ownerId + " - " + ownerName;
 
                     rowPanel.setEntityName("", entityName);
                     rowPanel.setEntitySubTitle(text, "");


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1158087

**PROBLEM**
If the comment text is too long, then the title of the comment row is trimmed. The problem seems to be from the html tags that wrapped the text of the title.

**SOLUTION**
Removed the html tags and changed the way that the title is displayed.