### PR TITLE
defect #1158087: Remove bdd scenario from Entity field map if the version of Octane is lower than 15.1.4

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeCellRenderer.java
@@ -429,4 +429,9 @@ public class EntityTreeCellRenderer implements TreeCellRenderer {
         return "<html><body>" + string + "</body></html>";
     }
 
+    public static void removeBddFromEntityFields() {
+        if (entityFields.containsKey(Entity.BDD_SCENARIO)) {
+            entityFields.remove(Entity.BDD_SCENARIO);
+        }
+    }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
@@ -35,10 +35,13 @@ import com.hpe.adm.octane.ideplugins.intellij.ui.util.UiUtil;
 import com.hpe.adm.octane.ideplugins.services.CommentService;
 import com.hpe.adm.octane.ideplugins.services.EntityLabelService;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
+import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettingsProvider;
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;
 import com.hpe.adm.octane.ideplugins.services.mywork.MyWorkService;
 import com.hpe.adm.octane.ideplugins.services.mywork.MyWorkUtil;
+import com.hpe.adm.octane.ideplugins.services.nonentity.OctaneVersionService;
 import com.hpe.adm.octane.ideplugins.services.util.EntityUtil;
+import com.hpe.adm.octane.ideplugins.services.util.OctaneVersion;
 import com.hpe.adm.octane.ideplugins.services.util.PartialEntity;
 import com.hpe.adm.octane.ideplugins.services.util.Util;
 import com.intellij.icons.AllIcons;
@@ -94,6 +97,9 @@ public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
     @Inject
     private CommentService commentService;
 
+    @Inject
+    private ConnectionSettingsProvider connectionSettingsProvider;
+
     public EntityTreeTablePresenter() {
     }
 
@@ -102,6 +108,13 @@ public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
             public void run(@NotNull ProgressIndicator indicator) {
                 try {
                     entityTreeTableView.setLoading(true);
+
+                    // remove BDD from EntityFieldMap for Octane versions lower than Coldplay P1 ( 15.1.4 - version where BDD was implemented )
+                    OctaneVersion octaneVersion = OctaneVersionService.getOctaneVersion(connectionSettingsProvider.getConnectionSettings());
+                    if (octaneVersion.isLessOrEqThan(OctaneVersion.COLDPLAY_P1)) {
+                        EntityTreeCellRenderer.removeBddFromEntityFields();
+                    }
+
                     Collection<EntityModel> myWork = myWorkService.getMyWork(EntityTreeCellRenderer.getEntityFieldMap());
 
                     SwingUtilities.invokeLater(() -> {


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1158087

**PROBLEM**
The plugin throws error and does not work at all if the Octane version is lower than 15.1.4 ( version of Octane where BDD was implemented ), because of the BDD entity.

**SOLUTION**
Removed the BDD from Entity Field map if the octane version is lower than 15.1.4, before using the map, so it won't send wrong request to server.