### PR TITLE
defect #1158087: Fix search for older octane versions

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/EntitySearchResultPresenter.java
@@ -264,11 +264,14 @@ public class EntitySearchResultPresenter implements Presenter<EntityTreeView> {
 
     private static Entity[] addEntityType(Entity searchEntityTypes[], Entity newType) {
         Entity searchEntityTypesCopy[] = new Entity[searchEntityTypes.length + 1];
-        for (int i = 0; i < searchEntityTypes.length; i++)
-            if (searchEntityTypes[i] != newType) // if the type was already added, return initial array
+        for (int i = 0; i < searchEntityTypes.length; i++) {
+            if (searchEntityTypes[i] != newType) { // if the type was already added, return initial array
                 searchEntityTypesCopy[i] = searchEntityTypes[i];
-            else
+            }
+            else {
                 return searchEntityTypes;
+            }
+        }
         searchEntityTypesCopy[searchEntityTypes.length] = newType;
 
         return searchEntityTypesCopy;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeTablePresenter.java
@@ -111,7 +111,7 @@ public class EntityTreeTablePresenter implements Presenter<EntityTreeView> {
 
                     // remove BDD from EntityFieldMap for Octane versions lower than Coldplay P1 ( 15.1.4 - version where BDD was implemented )
                     OctaneVersion octaneVersion = OctaneVersionService.getOctaneVersion(connectionSettingsProvider.getConnectionSettings());
-                    if (octaneVersion.isLessOrEqThan(OctaneVersion.COLDPLAY_P1)) {
+                    if (octaneVersion.isLessThan(OctaneVersion.COLDPLAY_P1)) {
                         EntityTreeCellRenderer.removeBddFromEntityFields();
                     }
 


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1158087

**PROBLEM**
The plugin throws error and the search does not work if the Octane server version is older.

**SOLUTION**
Added the BDD to searchEntityTypes array if the octane version is higher or equal than 15.1.4, before using the array, so it won't send wrong request to server.