### PR TITLE
defect #1413033: fix phase transition

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/customcomponents/PhaseDropDownMenu.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/customcomponents/PhaseDropDownMenu.java
@@ -123,7 +123,7 @@ public class PhaseDropDownMenu extends JPanel {
             String phase = Util.getUiDataFromModel(e.getValue("target_phase"), "name");
             // don't put the phase which is already in the target label into the
             // popup menu
-            if (!targetPhaseLabel.getText().contains(phase)) {
+            if (!targetPhaseLabel.getText().substring(MOVE_TO.length()).equals(phase)) {
                 JMenuItem menuItem = new JMenuItem(phase);
                 labelPhaseMap.put(menuItem, e.getValue("target_phase"));
             }


### PR DESCRIPTION
**problem**: "Closed" transition did not appeared when trying to switch the phase of an entity from "Fixed" to "Closed"

when getting all the possible phases that an entity can be switched to, the verification which excluded the phase that is in the target label was done by checking if the target label contains the current phase and it was incorrect.

for example: he have in target label "Move to: Proposed closed" and the phases that needs to appear in the dropdown are "Closed" and "Opened", but in this case the target label contains the string "closed", so it won't add it to the dropdown list.

**solution**: the "Move to: " string was ignored from the target label verification and it was done by checking is the strings are equal.
