### PR TITLE
defect #1159018: fix octane preload gif error

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/customcomponents/LoadingWidget.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/customcomponents/LoadingWidget.java
@@ -26,7 +26,7 @@ public class LoadingWidget extends JPanel {
 
     public LoadingWidget(String loadingMessage) {
         setLayout(new BorderLayout(0, 0));
-        ImageIcon pacmanImage = new ImageIcon(LoadingWidget.class.getClassLoader().getResource(Constants.IMG_AJAX_SPINNER));
+        ImageIcon pacmanImage = new ImageIcon(LoadingWidget.class.getResource(Constants.IMG_AJAX_SPINNER));
         JLabel loadingLabel = new JLabel(pacmanImage);
         //loadingLabel.setText(loadingMessage);
         add(loadingLabel, BorderLayout.CENTER);


### PR DESCRIPTION
problem: exception thrown everytime the octane gif appeared in my work.

solution: the class that loaded that gif, the image resource was not correctly called.

explanation: Leading slash works only for class.getResource() to override its default behavior. There is no leading slash concept for class.getClassLoader().getResource(), so it always returns null