### PR TITLE
defect #1431008: fix datetime picker

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/field/DateTimeFieldEditor.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/field/DateTimeFieldEditor.java
@@ -237,8 +237,7 @@ public class DateTimeFieldEditor extends FieldEditor {
         LocalDate localDate = microbaDatePicker.getDate()
                 .toInstant()
                 .atZone(ZoneId.systemDefault()).toLocalDate();
-        //Date uses 0 based numbering while ZonedDateTime uses 1 based numbering
-        localDate = localDate.plusMonths(1);
+
         // Converting to UTC is not necessary, the SDK will do it for you
         return ZonedDateTime.of(localDate,
                 LocalTime.of(


### PR DESCRIPTION
problem: when setting the date for "Closed on" field for an entity and then saving it, it would've save it with +1 month.

(setting the field to 25-Nov-2021 would save the entity with 25-Dec-2021)