### PR TITLE
defect #2406156: changed Suite Run entity color from light blue to purple

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/entityicon/EntityIconFactory.java
@@ -115,7 +115,7 @@ public class EntityIconFactory {
         entityColorMap.put(Entity.GHERKIN_TEST, new Color(0, 169, 137));
         entityColorMap.put(Entity.TEST_SUITE, new Color(39, 23, 130));
         entityColorMap.put(Entity.MANUAL_TEST_RUN, new Color(0, 171, 243));
-        entityColorMap.put(Entity.TEST_SUITE_RUN, new Color(0, 171, 243));
+        entityColorMap.put(Entity.TEST_SUITE_RUN, new Color(82, 22, 172));
         entityColorMap.put(Entity.AUTOMATED_TEST, new Color(186, 71, 226));
         entityColorMap.put(Entity.COMMENT, new Color(253, 225, 89));
         entityColorMap.put(Entity.REQUIREMENT, new Color(11, 142, 172));


### PR DESCRIPTION
[https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2406156](https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2406156)

**Problem:** Suite Run entity color in Intellij plugin is different from the Suite Run entity color in Octane. The color is light blue in Intellij plugin and it should be purple as it is in Octane.

**Solution:** I changed the Suite Run entity color in Intellij plugin from light blue to purple in order to match the entity color in Octane.