### PR TITLE
defect #2362014: added full commit message when copying to clipboard

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/gitcommit/CommitMessageUtils.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/gitcommit/CommitMessageUtils.java
@@ -119,6 +119,7 @@ public class CommitMessageUtils {
 
         String id = entityModel.getId();
         Entity type = Entity.getEntityType(entityModel);
+        String commitMessage = ": my commit message";
 
         switch (type) {
             case USER_STORY:
@@ -134,6 +135,7 @@ public class CommitMessageUtils {
 
         messageBuilder.append(id);
         messageBuilder.append(taskString);
+        messageBuilder.append(commitMessage);
         return messageBuilder.toString();
     }
 


### PR DESCRIPTION
[https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2362014](https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2362014)

**Problem:** When user tries to copy commit message to clipboard it will be only copied as "defect #1234", instead of "defect #1234: my commit message".

**Solution:** I added full commit message text ("defect #1234: my commit message") when user copies message to clipboard.