### PR TITLE
defect #2288171: fixed save button visibility

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/SaveCurrentEntityAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/SaveCurrentEntityAction.java
@@ -38,7 +38,7 @@ import com.intellij.openapi.util.IconLoader;
 public final class SaveCurrentEntityAction extends OctanePluginAction {
 
     public SaveCurrentEntityAction() {
-        super("Save backlog item", "Save changes to backlog item.", IconLoader.findIcon("/actions/menu-saveall.png", SaveCurrentEntityAction.class.getClassLoader()));
+        super("Save backlog item", "Save changes to backlog item.", IconLoader.findIcon("/actions/menu-saveall.svg", SaveCurrentEntityAction.class.getClassLoader()));
     }
 
     public void update(AnActionEvent e) {


### PR DESCRIPTION
[https://center.almoctane.com/ui/?p=1001/1002#/team-backlog/stories](https://center.almoctane.com/ui/?p=1001/1002#/team-backlog/stories)

**Problem:** The icon for "save backlog item" button wasn't visible.

**Solution:** I ensured the correct path is utilized for retrieving the icon associated with the "save backlog item" button. Users will now be able to identify and interact with the button, regardless of their selected theme.
![save_button](https://github.com/MicroFocus/octane-intellij-plugin/assets/157134806/c707afe5-98c1-44c2-94bd-76403cac28e4)
![save_button_white](https://github.com/MicroFocus/octane-intellij-plugin/assets/157134806/f6fddff6-4dfa-444f-b589-e0f23d52ac56)
