### PR TITLE
defect #2288167: display active item section on main toolbar new UI;

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -327,7 +327,10 @@
         </action>
 
         <group id="com.hpe.adm.octane.ideplugins.intellij.ActiveItemActions" text="ValueEdge Active Item">
-            <add-to-group group-id="MainToolBar" anchor="last"/>
+            <!--new UI -->
+            <add-to-group group-id="MainToolbarRight" anchor="first"/>
+
+            <!--old UI -->
             <add-to-group group-id="NavBarToolBar" anchor="first"/>
 
             <separator/>


### PR DESCRIPTION
[https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2288167](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2288167)

Added the "ValueEdge Active Item" section into the toolbar menu, ensuring its visibility in both the old and new UI of IntelliJ.

