### PR TITLE
Center search bar 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     }
 
     //use javafx modules only at compile time based on the current OS
-    def javaFxVersion = '11.0.2'
+    def javaFxVersion = '17.0.11'
     def javaFxModules = ['graphics', 'swing', 'base', 'web']
     def currentOS = org.gradle.internal.os.OperatingSystem.current()
     def platform

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     }
 
     //use javafx modules only at compile time based on the current OS
-    def javaFxVersion = '17.0.11'
+    def javaFxVersion = '11.0.2'
     def javaFxModules = ['graphics', 'swing', 'base', 'web']
     def currentOS = org.gradle.internal.os.OperatingSystem.current()
     def platform

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/CustomSearchTextField.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/searchresult/CustomSearchTextField.java
@@ -155,7 +155,7 @@ public class CustomSearchTextField extends JPanel {
         });
 
         myToggleHistoryLabel = new JLabel(new ImageIcon(Objects.requireNonNull(CustomSearchTextField.class.getResource(Constants.IMG_SEARCH_ICON))));
-        myToggleHistoryLabel.setBorder(BorderFactory.createEmptyBorder(0, 3, 0, 0));
+        myToggleHistoryLabel.setBorder(BorderFactory.createEmptyBorder(2, 3, 0, 0));
         myToggleHistoryLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         myToggleHistoryLabel.setOpaque(true);
         myToggleHistoryLabel.addMouseListener(new MouseAdapter() {
@@ -190,7 +190,7 @@ public class CustomSearchTextField extends JPanel {
         myToggleHistoryLabel.setBackground(myTextField.getBackground());
         myClearFieldLabel.setBackground(myTextField.getBackground());
 
-        setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(2, 0, 0, 15), originalBorder));
+        setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(-4, 0, 0, 15), originalBorder));
 
         myTextField.setOpaque(true);
         myTextField.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 5));


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2167098

Made the search bar fit in the "div" (don't know how it's called) properly, so that we can see the bottom part and the upper part. 
Because of the change above, also moved the "search" icon a little lower to be as "centered as possible"

<img width="1386" alt="image" src="https://github.com/MicroFocus/octane-intellij-plugin/assets/34449887/a54f85bd-993d-4cab-8e9d-1985e8f2e129">
