### PR TITLE
defect #2520130: bumped javaFX version from 11 to 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     }
 
     //use javafx modules only at compile time based on the current OS
-    def javaFxVersion = '11.0.2'
+    def javaFxVersion = '17.0.11'
     def javaFxModules = ['graphics', 'swing', 'base', 'web']
     def currentOS = org.gradle.internal.os.OperatingSystem.current()
     def platform


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2520130

bumped version for javaFX from 11 to 17 