### PR TITLE
defect #2651009: move every action to EDT; for Open active item, Copy  commit and Stop active item actions are now using executeOnPooledThread to start loading data on BGT and then using invokeLater to update the UI on EDT

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/actions/OpenMyWorkAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/actions/OpenMyWorkAction.java
@@ -32,11 +32,13 @@ package com.hpe.adm.octane.ideplugins.intellij.actions;
 import com.hpe.adm.octane.ideplugins.intellij.PluginModule;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.hpe.adm.octane.ideplugins.intellij.ui.tabbedpane.TabbedPanePresenter;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
+import org.jetbrains.annotations.NotNull;
 
 public class OpenMyWorkAction extends AnAction {
 
@@ -60,4 +62,8 @@ public class OpenMyWorkAction extends AnAction {
         tabbedPanePresenter.selectMyWorkTab();
     }
 
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/actions/RefreshCurrentEntityAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/actions/RefreshCurrentEntityAction.java
@@ -33,8 +33,10 @@ import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Presenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.detail.EntityDetailPresenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.treetable.EntityTreeTablePresenter;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.util.IconLoader;
+import org.jetbrains.annotations.NotNull;
 
 public class RefreshCurrentEntityAction extends OctanePluginAction {
 
@@ -42,6 +44,7 @@ public class RefreshCurrentEntityAction extends OctanePluginAction {
         super("Refresh backlog item", "Refresh backlog item details.", IconLoader.findIcon(Constants.IMG_REFRESH_ICON, RefreshCurrentEntityAction.class.getClassLoader()));
     }
 
+    @Override
     public void actionPerformed(AnActionEvent e) {
         Presenter presenter = getSelectedPresenter(e);
 
@@ -56,5 +59,10 @@ public class RefreshCurrentEntityAction extends OctanePluginAction {
             ((EntityDetailPresenter) presenter).refresh();
         }
 
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/actions/activeitem/StopActiveItemAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/actions/activeitem/StopActiveItemAction.java
@@ -34,6 +34,7 @@ import com.hpe.adm.octane.ideplugins.intellij.settings.IdePluginPersistentState;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.IconLoader;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
@@ -46,9 +47,14 @@ public class StopActiveItemAction extends OctanePluginAction {
 
     @Override
     public void update(AnActionEvent e) {
-        getPluginModule(e).ifPresent(pluginModule -> {
-            JSONObject jsonObject = pluginModule.getInstance(IdePluginPersistentState.class).loadState(IdePluginPersistentState.Key.ACTIVE_WORK_ITEM);
-            e.getPresentation().setEnabled(jsonObject != null);
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            getPluginModule(e).ifPresent(pluginModule -> {
+                JSONObject jsonObject = pluginModule.getInstance(IdePluginPersistentState.class).loadState(IdePluginPersistentState.Key.ACTIVE_WORK_ITEM);
+
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    e.getPresentation().setEnabled(jsonObject != null);
+                });
+            });
         });
     }
 
@@ -63,6 +69,6 @@ public class StopActiveItemAction extends OctanePluginAction {
 
     @Override
     public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.BGT;
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/EntityDetailView.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/EntityDetailView.java
@@ -45,6 +45,7 @@ import com.hpe.adm.octane.ideplugins.intellij.util.ExceptionHandler;
 import com.hpe.adm.octane.ideplugins.intellij.util.RestUtil;
 import com.hpe.adm.octane.ideplugins.services.CommentService;
 import com.hpe.adm.octane.ideplugins.services.model.EntityModelWrapper;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -52,6 +53,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBScrollPane;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
@@ -273,8 +275,14 @@ public class EntityDetailView extends JPanel implements View {
             super("Show comments for current entity", "Show comments for current entity", IconLoader.findIcon(Constants.IMG_COMMENTS_ICON, EntityDetailView.class.getClassLoader()));
         }
 
+        @Override
         public void actionPerformed(AnActionEvent e) {
             showCommentsPanel(!isCommentsPanelVisible);
+        }
+
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.EDT;
         }
     }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/PhaseComboBoxAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/PhaseComboBoxAction.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 public final class PhaseComboBoxAction extends ComboBoxAction {
+    @Override
     public void update(final AnActionEvent event) {
         Presentation presentation = event.getPresentation();
         Project project = event.getData(CommonDataKeys.PROJECT);

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/PhaseItemAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/PhaseItemAction.java
@@ -31,10 +31,12 @@ package com.hpe.adm.octane.ideplugins.intellij.ui.detail.actions;
 
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 
 
 public class PhaseItemAction extends AnAction {
@@ -75,4 +77,8 @@ public class PhaseItemAction extends AnAction {
         updateIcon(e.getPresentation());
     }
 
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/SaveCurrentEntityAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/SaveCurrentEntityAction.java
@@ -32,8 +32,10 @@ package com.hpe.adm.octane.ideplugins.intellij.ui.detail.actions;
 import com.hpe.adm.octane.ideplugins.intellij.actions.OctanePluginAction;
 import com.hpe.adm.octane.ideplugins.intellij.ui.Presenter;
 import com.hpe.adm.octane.ideplugins.intellij.ui.detail.EntityDetailPresenter;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.util.IconLoader;
+import org.jetbrains.annotations.NotNull;
 
 public final class SaveCurrentEntityAction extends OctanePluginAction {
 
@@ -41,6 +43,7 @@ public final class SaveCurrentEntityAction extends OctanePluginAction {
         super("Save backlog item", "Save changes to backlog item.", IconLoader.findIcon("/actions/menu-saveall.svg", SaveCurrentEntityAction.class.getClassLoader()));
     }
 
+    @Override
     public void update(AnActionEvent e) {
         Presenter presenter = getSelectedPresenter(e);
         if (presenter instanceof EntityDetailPresenter) {
@@ -48,6 +51,7 @@ public final class SaveCurrentEntityAction extends OctanePluginAction {
         }
     }
 
+    @Override
     public void actionPerformed(AnActionEvent e) {
         Presenter presenter = getSelectedPresenter(e);
         if (presenter instanceof EntityDetailPresenter) {
@@ -55,4 +59,8 @@ public final class SaveCurrentEntityAction extends OctanePluginAction {
         }
     }
 
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/SelectFieldsAction.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/actions/SelectFieldsAction.java
@@ -31,9 +31,11 @@ package com.hpe.adm.octane.ideplugins.intellij.ui.detail.actions;
 
 import com.hpe.adm.octane.ideplugins.intellij.ui.Constants;
 import com.hpe.adm.octane.ideplugins.intellij.ui.detail.EntityDetailView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.util.IconLoader;
+import org.jetbrains.annotations.NotNull;
 
 public final class SelectFieldsAction extends AnAction {
 
@@ -49,15 +51,22 @@ public final class SelectFieldsAction extends AnAction {
         this.entityDetailView = entityDetailView;
     }
 
+    @Override
     public void actionPerformed(AnActionEvent e) {
         entityDetailView.showFieldsSettings();
     }
 
+    @Override
     public void update(AnActionEvent e) {
         if (defaultfields) {
             e.getPresentation().setIcon(IconLoader.findIcon(Constants.IMG_FIELD_SELECTION_DEFAULT, SelectFieldsAction.class.getClassLoader()));
         } else {
             e.getPresentation().setIcon(IconLoader.findIcon(Constants.IMG_FIELD_SELECTION_NON_DEFAULT, SelectFieldsAction.class.getClassLoader()));
         }
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/HeaderPanel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/detail/entityfields/HeaderPanel.java
@@ -44,6 +44,7 @@ import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import javax.swing.border.MatteBorder;
@@ -314,8 +315,14 @@ public class HeaderPanel extends JPanel {
 
         }
 
+        @Override
         public void actionPerformed(AnActionEvent e) {
             entityService.openInBrowser(entityModelWrapper.getEntityModel());
+        }
+
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.EDT;
         }
     }
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/tabbedpane/TabbedPaneView.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/tabbedpane/TabbedPaneView.java
@@ -263,6 +263,11 @@ public class TabbedPaneView implements View {
                 }
             }
         }
+
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.EDT;
+        }
     }
 
 }

--- a/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeView.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/intellij/ui/treetable/EntityTreeView.java
@@ -47,6 +47,7 @@ import com.intellij.ui.components.JBScrollPane;
 import jakarta.inject.Provider;
 import org.jdesktop.swingx.JXHyperlink;
 import org.jdesktop.swingx.JXLabel;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import javax.swing.tree.TreeCellRenderer;
@@ -70,10 +71,15 @@ public class EntityTreeView implements View {
             this.treeView = treeView;
         }
 
+        @Override
         public void actionPerformed(AnActionEvent e) {
             treeView.expandAllNodes();
         }
 
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.EDT;
+        }
     }
 
     public static class CollapseNodesAction extends AnAction {
@@ -84,8 +90,14 @@ public class EntityTreeView implements View {
             this.treeView = treeView;
         }
 
+        @Override
         public void actionPerformed(AnActionEvent e) {
             treeView.collapseAllNodes();
+        }
+
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.EDT;
         }
     }
 


### PR DESCRIPTION
(EDT: Event Dispatch Thread - UI changes; BGT: Background Thread - long tasks)

- move every action to EDT; 
- for Open active item, Copy  commit and Stop active item actions are now using executeOnPooledThread to start loading data on BGT and then using invokeLater to update the UI on EDT